### PR TITLE
(chore): remove all `.fernignored` files

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,7 +1,3 @@
 # Specify files that shouldn't be modified by Fern
-src/wrapper/
-src/environments.ts
-src/core/auth/OAuthTokenProvider.ts
-src/index.ts
 
 README.md


### PR DESCRIPTION
Removes all fernignored files so that all of the `OAuth` code is updated by the generator on a regular basis. 